### PR TITLE
Add \maketitle for engwales-plead

### DIFF
--- a/engwales-plead.sty
+++ b/engwales-plead.sty
@@ -1,6 +1,6 @@
 \ProvidesPackage{engwales-plead}[2021-02-13 Package for pleading creation in England/Wales styles]
 
-\RequirePackage{soul}  % spaceout boxes
+\RequirePackage{soul}  % spaced out boxes
 \RequirePackage[normalem]{ulem}
 
 \newcommand\court[1]{\def\@court{#1}}
@@ -10,8 +10,7 @@
 
 \renewcommand\maketitle{%
   \begingroup
-  \linespread{1.5}
-  \setlength\parindent{0pt}\bfseries
+  \linespread{1.5}\setlength\parindent{0pt}\bfseries
   \parbox[t]{.65\textwidth}{\uline{\@court}}
   Case No~\@casenumber
 

--- a/engwales-plead.sty
+++ b/engwales-plead.sty
@@ -1,0 +1,28 @@
+\ProvidesPackage{engwales-plead}[2021-02-13 Package for pleading creation in England/Wales styles]
+
+\RequirePackage{soul}  % spaceout boxes
+\RequirePackage[normalem]{ulem}
+
+\newcommand\court[1]{\def\@court{#1}}
+\newcommand\casenumber[1]{\def\@casenumber{#1}}
+\newcommand\claimant[1]{\def\@claimant{#1}}
+\newcommand\defendant[1]{\def\@defendant{#1}}
+
+\renewcommand\maketitle{%
+  \begingroup
+  \linespread{1.5}
+  \setlength\parindent{0pt}\bfseries
+  \parbox[t]{.65\textwidth}{\uline{\@court}}
+  Case No~\@casenumber
+
+  \vspace{24pt}
+
+  \so{BETWEEN}
+  \begin{center}\@claimant\end{center}
+  \begin{flushright}\uline{Claimant}\end{flushright}
+  \begin{center}and\end{center}
+  \begin{flushright}\end{flushright}
+  \begin{center}\@defendant\end{center}
+  \begin{flushright}\uline{Defendant}\end{flushright}
+  \endgroup
+}

--- a/examples/pleading.tex
+++ b/examples/pleading.tex
@@ -15,8 +15,6 @@
 
 \begin{document}
 \maketitle
-\section{%
-  PARTICULARS OF CLAIM
-}
+\section{PARTICULARS OF CLAIM}
 \blindtext
 \end{document}

--- a/examples/pleading.tex
+++ b/examples/pleading.tex
@@ -1,0 +1,22 @@
+\documentclass[a4paper]{article}
+\usepackage{../engwales-plead}
+
+\casenumber{1}
+\claimant{[CLAIMANT]}
+\defendant{[DEFENDANT]}
+\court{%
+  IN THE HIGH COURT OF JUSTICE \\
+  QUEEN'S BENCH DIVISION \\
+  MEDIA AND COMMUNICATIONS LIST
+}
+
+\usepackage[margin=2.5cm]{geometry}
+\usepackage{blindtext}
+
+\begin{document}
+\maketitle
+\section{%
+  PARTICULARS OF CLAIM
+}
+\blindtext
+\end{document}


### PR DESCRIPTION
This aims to replicate "Particulars of Claim, first page.docx."

I wasn't sure whether the "Particulars of claim" was part of the title (or just a section name) so I left it out of the command and it is currently *unformatted*.

Preview: 
![image](https://user-images.githubusercontent.com/10174018/107861850-70b51080-6dfd-11eb-858f-9700f8931ed5.png)