### PR TITLE
Add tram-lined title to \maketitle

### DIFF
--- a/engwales-plead.sty
+++ b/engwales-plead.sty
@@ -23,5 +23,17 @@
   \begin{flushright}\end{flushright}
   \begin{center}\@defendant\end{center}
   \begin{flushright}\uline{Defendant}\end{flushright}
+
+  \vspace{0pt}
+
+  \begin{center}
+    \renewcommand\arrayrulewidth{1.1pt}
+    \begin{tabular}{@{\hspace{12pt}}c@{\hspace{12pt}}}
+      \hline\\[-12pt]
+      \@title\\\ \\[-12pt]
+      \hline
+    \end{tabular}
+  \end{center}
+  \vspace{24pt}
   \endgroup
 }

--- a/examples/pleading.tex
+++ b/examples/pleading.tex
@@ -9,12 +9,16 @@
   QUEEN'S BENCH DIVISION \\
   MEDIA AND COMMUNICATIONS LIST
 }
+\title{PARTICULARS OF CLAIM}
+% \title{%
+% SKELETON ARGUMENT FOR THE APPLICANT \\
+% REQUEST FOR SUMMARY JUDGMENT
+% }
 
 \usepackage[margin=2.5cm]{geometry}
 \usepackage{blindtext}
 
 \begin{document}
 \maketitle
-\section{PARTICULARS OF CLAIM}
 \blindtext
 \end{document}


### PR DESCRIPTION
hot fix for #5. add the "Particulars of Claim" as part of `\maketitle` (thru `\title{PARTICULAR OF CLAIMS}`) with the surrounding tram lines.

@passamo9: did not use your solution suggested in [comment in #5](https://github.com/passamo9/LaTeX_EnglandWales_Templates/pull/5#issuecomment-778680036) because it doesn't work for multi-line titles (for example `\title{SKELETON ARGUMENT FOR THE APPLICANT \\ REQUEST FOR SUMMARY JUDGMENT}`).