### PR TITLE
Fix latexmk ci not updating existing example PDFs.

### DIFF
--- a/.github/workflows/latexmk.yml
+++ b/.github/workflows/latexmk.yml
@@ -26,9 +26,15 @@ jobs:
       - if: github.event_name == 'push'
         name: Upload PDF to examples branch
         run: |
+          cd "$(git rev-parse --show-toplevel)/examples"
           git fetch origin examples
-          git checkout -b examples origin/examples --merge
+          rm -rf /tmp/pdfs
+          mkdir -p /tmp/pdfs/
+          for f in *.pdf; do mv -f "$f" /tmp/pdfs/; done
+          git checkout -b examples origin/examples
+          git clean -df
+          for f in /tmp/pdfs/*.pdf; do mv -f "$f" ./; done
           git add *.pdf
-          git status | grep -q 'nothing added to commit' && exit
-          git commit -m "ci: Update example PDFs."
+          git status
+          git commit -m "ci: Update example PDFs." --no-allow-empty || exit 0
           git push origin examples


### PR DESCRIPTION
[this ci](https://github.com/passamo9/LaTeX_EnglandWales_Templates/runs/1906362363) should have updated pleading.pdf but it didn't (check "Upload PDF to examples branch" step).

maybe git handles binary file merging differently among versions. anyways it's probably not a good idea to rely on it. new approach: copy the PDFs into the repo.

also changed approach to handle the case where there's no updates to PDFs. previously by checking the status message but apparently the wording varies among git versions. new approach: try commit anyway and catches failure if applicable.

tested locally (don't have a better way yet. also this is NOT checked in the PR checks since PDF uploading is skipped in PRs). hopefully this will work XD